### PR TITLE
Get rid of unsafe in entry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,20 +94,12 @@ where
         }
 
         let bucket = self.bucket(&key);
-
-        for entry in &mut self.buckets[bucket] {
-            if entry.0 == key {
-                return Entry::Occupied(OccupiedEntry {
-                    entry: unsafe { &mut *(entry as *mut _) },
-                });
-            }
+        match self.buckets[bucket].iter().position(|&(ref ekey, _)| ekey == &key) {
+            Some(index) => Entry::Occupied(OccupiedEntry {
+                entry: &mut self.buckets[bucket][index]
+            }),
+            None => Entry::Vacant(VacantEntry { map: self, key, bucket })
         }
-
-        Entry::Vacant(VacantEntry {
-            key,
-            map: self,
-            bucket,
-        })
     }
 
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {


### PR DESCRIPTION
This isn't the most efficient way to do it - I can't imagine the index checks are all elided - but it works without unsafe, which should be a priority for this demo crate.

Nice stream BTW! One topic for another day could be to take one of the minor "sad" things and create a patch/PR to rustc on stream :smile: 