### PR TITLE
Empty HashMap should work correctly without an insert.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,14 +78,17 @@ impl<K, V> HashMap<K, V>
 where
     K: Hash + Eq,
 {
-    fn bucket<Q>(&self, key: &Q) -> usize
+    fn bucket<Q>(&self, key: &Q) -> Option<usize>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
+        if self.buckets.len() == 0 {
+            return None;
+        }
         let mut hasher = DefaultHasher::new();
         key.hash(&mut hasher);
-        (hasher.finish() % self.buckets.len() as u64) as usize
+        Some((hasher.finish() % self.buckets.len() as u64) as usize)
     }
 
     pub fn entry<'a>(&'a mut self, key: K) -> Entry<'a, K, V> {
@@ -93,7 +96,7 @@ where
             self.resize();
         }
 
-        let bucket = self.bucket(&key);
+        let bucket = self.bucket(&key).unwrap();
         match self.buckets[bucket].iter().position(|&(ref ekey, _)| ekey == &key) {
             Some(index) => Entry::Occupied(OccupiedEntry {
                 entry: &mut self.buckets[bucket][index]
@@ -107,7 +110,7 @@ where
             self.resize();
         }
 
-        let bucket = self.bucket(&key);
+        let bucket = self.bucket(&key).unwrap();
         let bucket = &mut self.buckets[bucket];
 
         for &mut (ref ekey, ref mut evalue) in bucket.iter_mut() {
@@ -126,10 +129,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if self.is_empty() {
-            return None;
-        }
-        let bucket = self.bucket(key);
+        let bucket = self.bucket(key)?;
         self.buckets[bucket]
             .iter()
             .find(|&(ref ekey, _)| ekey.borrow() == key)
@@ -141,11 +141,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if self.is_empty() {
-            false
-        } else {
-            self.get(key).is_some()
-        }
+        self.get(key).is_some()
     }
 
     pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
@@ -153,10 +149,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if self.is_empty() {
-            return None;
-        }
-        let bucket = self.bucket(key);
+        let bucket = self.bucket(key)?;
         let bucket = &mut self.buckets[bucket];
         let i = bucket
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if self.buckets.len() == 0 {
+        if self.buckets.is_empty() {
             return None;
         }
         let mut hasher = DefaultHasher::new();
@@ -96,7 +96,7 @@ where
             self.resize();
         }
 
-        let bucket = self.bucket(&key).unwrap();
+        let bucket = self.bucket(&key).expect("buckets.is_empty() handled above");
         match self.buckets[bucket].iter().position(|&(ref ekey, _)| ekey == &key) {
             Some(index) => Entry::Occupied(OccupiedEntry {
                 entry: &mut self.buckets[bucket][index]
@@ -110,7 +110,7 @@ where
             self.resize();
         }
 
-        let bucket = self.bucket(&key).unwrap();
+        let bucket = self.bucket(&key).expect("buckets.is_empty() handled above");
         let bucket = &mut self.buckets[bucket];
 
         for &mut (ref ekey, ref mut evalue) in bucket.iter_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,9 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
+        if self.is_empty() {
+            return None;
+        }
         let bucket = self.bucket(key);
         self.buckets[bucket]
             .iter()
@@ -138,7 +141,11 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        self.get(key).is_some()
+        if self.is_empty() {
+            false
+        } else {
+            self.get(key).is_some()
+        }
     }
 
     pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
@@ -146,6 +153,9 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
+        if self.is_empty() {
+            return None;
+        }
         let bucket = self.bucket(key);
         let bucket = &mut self.buckets[bucket];
         let i = bucket
@@ -326,5 +336,13 @@ mod tests {
             items += 1;
         }
         assert_eq!(items, 4);
+    }
+
+    #[test]
+    fn empty_hashmap() {
+        let mut map = HashMap::<&str, &str>::new();
+        assert_eq!(map.contains_key("key"), false);
+        assert_eq!(map.get("key"), None);
+        assert_eq!(map.remove("key"), None);
     }
 }


### PR DESCRIPTION
Hey @jonhoo,

Thanks for the great content!

I am new to Rust, while implementing simple HashMap from Youtube video, I have come across this issue. I have added a fix for it. 

Let me know if you want me to change anything.